### PR TITLE
Add enum support and second test proto to hold builder test types

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ message HelloReply {
 }
 ```
 
+## Protobuf Version Support
+
+This utility currently only supports proto3.  It does not support some of the features of proto2, including extensions.
+
 ## Application Support
 
 This is **not** an exhaustive list

--- a/examples/helloworld/README.md
+++ b/examples/helloworld/README.md
@@ -8,6 +8,11 @@ This example is mostly copied directly from `grpc-elixir`, with the exception th
 
 ## Usage
 
+1. Fetch Protobuf Dependencies
+```shell
+git submodule init
+```
+
 1. Install deps and compile
 ```shell
 $ mix do deps.get, compile

--- a/lib/grpc_reflection/builder.ex
+++ b/lib/grpc_reflection/builder.ex
@@ -127,6 +127,7 @@ defmodule GrpcReflection.Builder do
     case descriptor do
       %Google.Protobuf.DescriptorProto{} -> %{response_stub | message_type: [descriptor]}
       %Google.Protobuf.ServiceDescriptorProto{} -> %{response_stub | service: [descriptor]}
+      %Google.Protobuf.EnumDescriptorProto{} -> %{response_stub | enum_type: [descriptor]}
     end
   end
 
@@ -152,6 +153,10 @@ defmodule GrpcReflection.Builder do
       "." <> symbol -> symbol
       symbol -> symbol
     end)
+  end
+
+  defp types_from_descriptor(%Google.Protobuf.EnumDescriptorProto{}) do
+    []
   end
 
   defp package_from_name(service_name) do

--- a/mix.exs
+++ b/mix.exs
@@ -73,5 +73,9 @@ defmodule GrpcReflection.MixProject do
         )
       end
     )
+
+    Mix.shell().cmd(
+      "protoc --elixir_out=#{options}:./test/support/protos --proto_path=priv/protos/ priv/protos/test_service.proto"
+    )
   end
 end

--- a/priv/protos/test_service.proto
+++ b/priv/protos/test_service.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/any.proto";
+
+package testservice;
+
+service TestService {
+  rpc CallFunction (TestRequest) returns (TestReply) {}
+}
+
+message TestRequest {
+  string name = 1;
+  Enum enum = 2;
+  oneof test_oneof {
+    string label = 3;
+    int32 value = 4;
+  }
+  map<string, int32> g = 5;
+  google.protobuf.Any instrument = 6;
+}
+
+message TestReply {
+  google.protobuf.Timestamp today = 2;
+}
+
+enum Enum {
+  A = 0;
+  B = 1;
+}

--- a/test/builder_test.exs
+++ b/test/builder_test.exs
@@ -1,0 +1,10 @@
+defmodule GrpcReflection.BuilderTest do
+  @moduledoc false
+
+  use ExUnit.Case
+
+  test "supports all reflection types" do
+    tree = GrpcReflection.Builder.build_reflection_tree([Testservice.TestService.Service])
+    assert %GrpcReflection.Service{services: [Testservice.TestService.Service]} = tree
+  end
+end

--- a/test/support/protos/test_service.pb.ex
+++ b/test/support/protos/test_service.pb.ex
@@ -1,0 +1,340 @@
+defmodule Testservice.Enum do
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.EnumDescriptorProto{
+      name: "Enum",
+      value: [
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "A",
+          number: 0,
+          options: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "B",
+          number: 1,
+          options: nil,
+          __unknown_fields__: []
+        }
+      ],
+      options: nil,
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :A, 0
+  field :B, 1
+end
+
+defmodule Testservice.TestRequest.GEntry do
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "GEntry",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "key",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_INT32,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: %Google.Protobuf.MessageOptions{
+        message_set_wire_format: false,
+        no_standard_descriptor_accessor: false,
+        deprecated: false,
+        map_entry: true,
+        deprecated_legacy_json_field_conflicts: nil,
+        uninterpreted_option: [],
+        __pb_extensions__: %{},
+        __unknown_fields__: []
+      },
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :key, 1, type: :string
+  field :value, 2, type: :int32
+end
+
+defmodule Testservice.TestRequest do
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestRequest",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "name",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "name",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "enum",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_ENUM,
+          type_name: ".testservice.Enum",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "enum",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "label",
+          extendee: nil,
+          number: 3,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "label",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 4,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_INT32,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "g",
+          extendee: nil,
+          number: 5,
+          label: :LABEL_REPEATED,
+          type: :TYPE_MESSAGE,
+          type_name: ".testservice.TestRequest.GEntry",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "g",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "instrument",
+          extendee: nil,
+          number: 6,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".google.protobuf.Any",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "instrument",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [
+        %Google.Protobuf.DescriptorProto{
+          name: "GEntry",
+          field: [
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "key",
+              extendee: nil,
+              number: 1,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_STRING,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "key",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "value",
+              extendee: nil,
+              number: 2,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_INT32,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "value",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            }
+          ],
+          nested_type: [],
+          enum_type: [],
+          extension_range: [],
+          extension: [],
+          options: %Google.Protobuf.MessageOptions{
+            message_set_wire_format: false,
+            no_standard_descriptor_accessor: false,
+            deprecated: false,
+            map_entry: true,
+            deprecated_legacy_json_field_conflicts: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
+          oneof_decl: [],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        }
+      ],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [
+        %Google.Protobuf.OneofDescriptorProto{
+          name: "test_oneof",
+          options: nil,
+          __unknown_fields__: []
+        }
+      ],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  oneof :test_oneof, 0
+
+  field :name, 1, type: :string
+  field :enum, 2, type: Testservice.Enum, enum: true
+  field :label, 3, type: :string, oneof: 0
+  field :value, 4, type: :int32, oneof: 0
+  field :g, 5, repeated: true, type: Testservice.TestRequest.GEntry, map: true
+  field :instrument, 6, type: Google.Protobuf.Any
+end
+
+defmodule Testservice.TestReply do
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestReply",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "today",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".google.protobuf.Timestamp",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "today",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :today, 2, type: Google.Protobuf.Timestamp
+end
+
+defmodule Testservice.TestService.Service do
+  use GRPC.Service, name: "testservice.TestService", protoc_gen_elixir_version: "0.12.0"
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.ServiceDescriptorProto{
+      name: "TestService",
+      method: [
+        %Google.Protobuf.MethodDescriptorProto{
+          name: "CallFunction",
+          input_type: ".testservice.TestRequest",
+          output_type: ".testservice.TestReply",
+          options: %Google.Protobuf.MethodOptions{
+            deprecated: false,
+            idempotency_level: :IDEMPOTENCY_UNKNOWN,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
+          client_streaming: false,
+          server_streaming: false,
+          __unknown_fields__: []
+        }
+      ],
+      options: nil,
+      __unknown_fields__: []
+    }
+  end
+
+  rpc :CallFunction, Testservice.TestRequest, Testservice.TestReply
+end
+
+defmodule Testservice.TestService.Stub do
+  use GRPC.Stub, service: Testservice.TestService.Service
+end


### PR DESCRIPTION
Try to increase type compatibilities in the builder.  Found missing support for Enum.

Could not add support for extensions in current service protos as they are disabled in proto3, updating readme to show we currently only support proto3