### PR TITLE
add hooks to attempt proto2 support

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -74,8 +74,16 @@ defmodule GrpcReflection.MixProject do
       end
     )
 
-    Mix.shell().cmd(
-      "protoc --elixir_out=#{options}:./test/support/protos --proto_path=priv/protos/ priv/protos/test_service.proto"
+    Enum.each(
+      [
+        "priv/protos/test_service_v2.proto",
+        "priv/protos/test_service_v3.proto"
+      ],
+      fn reflection_proto ->
+        Mix.shell().cmd(
+          "protoc --elixir_out=#{options}:./test/support/protos --proto_path=priv/protos/ #{reflection_proto}"
+        )
+      end
     )
   end
 end

--- a/priv/protos/test_service_v2.proto
+++ b/priv/protos/test_service_v2.proto
@@ -1,27 +1,32 @@
-syntax = "proto3";
+syntax = "proto2";
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/any.proto";
 
-package testservice;
+package testserviceV2;
 
 service TestService {
   rpc CallFunction (TestRequest) returns (TestReply) {}
 }
 
 message TestRequest {
-  string name = 1;
-  Enum enum = 2;
+  required string name = 1;
+  optional Enum enum = 2;
   oneof test_oneof {
     string label = 3;
     int32 value = 4;
   }
   map<string, int32> g = 5;
-  google.protobuf.Any instrument = 6;
+  repeated google.protobuf.Any instrument = 6;
+  extensions 10 to 20;
+}
+
+extend TestRequest {
+   optional string extended_field = 10;
 }
 
 message TestReply {
-  google.protobuf.Timestamp today = 2;
+  required google.protobuf.Timestamp today = 2;
 }
 
 enum Enum {

--- a/priv/protos/test_service_v3.proto
+++ b/priv/protos/test_service_v3.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/any.proto";
+
+package testserviceV3;
+
+service TestService {
+  rpc CallFunction (TestRequest) returns (TestReply) {}
+}
+
+message TestRequest {
+  string name = 1;
+  Enum enum = 2;
+  oneof test_oneof {
+    string label = 3;
+    int32 value = 4;
+  }
+  map<string, int32> g = 5;
+  google.protobuf.Any instrument = 6;
+}
+
+message TestReply {
+  google.protobuf.Timestamp today = 2;
+}
+
+enum Enum {
+  A = 0;
+  B = 1;
+}

--- a/test/builder_test.exs
+++ b/test/builder_test.exs
@@ -3,8 +3,13 @@ defmodule GrpcReflection.BuilderTest do
 
   use ExUnit.Case
 
-  test "supports all reflection types" do
-    tree = GrpcReflection.Builder.build_reflection_tree([Testservice.TestService.Service])
-    assert %GrpcReflection.Service{services: [Testservice.TestService.Service]} = tree
+  test "supports all reflection types in proto3" do
+    tree = GrpcReflection.Builder.build_reflection_tree([TestserviceV3.TestService.Service])
+    assert %GrpcReflection.Service{services: [TestserviceV3.TestService.Service]} = tree
+  end
+
+  test "supports all reflection types in proto2" do
+    tree = GrpcReflection.Builder.build_reflection_tree([TestserviceV2.TestService.Service])
+    assert %GrpcReflection.Service{services: [TestserviceV2.TestService.Service]} = tree
   end
 end

--- a/test/builder_test.exs
+++ b/test/builder_test.exs
@@ -6,10 +6,52 @@ defmodule GrpcReflection.BuilderTest do
   test "supports all reflection types in proto3" do
     tree = GrpcReflection.Builder.build_reflection_tree([TestserviceV3.TestService.Service])
     assert %GrpcReflection.Service{services: [TestserviceV3.TestService.Service]} = tree
+
+    assert Map.keys(tree.files) == [
+             "google.protobuf.Any.proto",
+             "google.protobuf.Timestamp.proto",
+             "testserviceV3.Enum.proto",
+             "testserviceV3.TestReply.proto",
+             "testserviceV3.TestRequest.GEntry.proto",
+             "testserviceV3.TestRequest.proto",
+             "testserviceV3.TestService.proto"
+           ]
+
+    assert Map.keys(tree.symbols) == [
+             "google.protobuf.Any",
+             "google.protobuf.Timestamp",
+             "testserviceV3.Enum",
+             "testserviceV3.TestReply",
+             "testserviceV3.TestRequest",
+             "testserviceV3.TestRequest.GEntry",
+             "testserviceV3.TestService",
+             "testserviceV3.TestService.CallFunction"
+           ]
   end
 
   test "supports all reflection types in proto2" do
     tree = GrpcReflection.Builder.build_reflection_tree([TestserviceV2.TestService.Service])
     assert %GrpcReflection.Service{services: [TestserviceV2.TestService.Service]} = tree
+
+    assert Map.keys(tree.files) == [
+             "google.protobuf.Any.proto",
+             "google.protobuf.Timestamp.proto",
+             "testserviceV2.Enum.proto",
+             "testserviceV2.TestReply.proto",
+             "testserviceV2.TestRequest.GEntry.proto",
+             "testserviceV2.TestRequest.proto",
+             "testserviceV2.TestService.proto"
+           ]
+
+    assert Map.keys(tree.symbols) == [
+             "google.protobuf.Any",
+             "google.protobuf.Timestamp",
+             "testserviceV2.Enum",
+             "testserviceV2.TestReply",
+             "testserviceV2.TestRequest",
+             "testserviceV2.TestRequest.GEntry",
+             "testserviceV2.TestService",
+             "testserviceV2.TestService.CallFunction"
+           ]
   end
 end

--- a/test/support/protos/test_service_v2.pb.ex
+++ b/test/support/protos/test_service_v2.pb.ex
@@ -1,0 +1,349 @@
+defmodule TestserviceV2.Enum do
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.EnumDescriptorProto{
+      name: "Enum",
+      value: [
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "A",
+          number: 0,
+          options: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "B",
+          number: 1,
+          options: nil,
+          __unknown_fields__: []
+        }
+      ],
+      options: nil,
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :A, 0
+  field :B, 1
+end
+
+defmodule TestserviceV2.TestRequest.GEntry do
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "GEntry",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "key",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_INT32,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: %Google.Protobuf.MessageOptions{
+        message_set_wire_format: false,
+        no_standard_descriptor_accessor: false,
+        deprecated: false,
+        map_entry: true,
+        deprecated_legacy_json_field_conflicts: nil,
+        uninterpreted_option: [],
+        __pb_extensions__: %{},
+        __unknown_fields__: []
+      },
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :key, 1, optional: true, type: :string
+  field :value, 2, optional: true, type: :int32
+end
+
+defmodule TestserviceV2.TestRequest do
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestRequest",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "name",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_REQUIRED,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "name",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "enum",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_ENUM,
+          type_name: ".testserviceV2.Enum",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "enum",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "label",
+          extendee: nil,
+          number: 3,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "label",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 4,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_INT32,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "g",
+          extendee: nil,
+          number: 5,
+          label: :LABEL_REPEATED,
+          type: :TYPE_MESSAGE,
+          type_name: ".testserviceV2.TestRequest.GEntry",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "g",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "instrument",
+          extendee: nil,
+          number: 6,
+          label: :LABEL_REPEATED,
+          type: :TYPE_MESSAGE,
+          type_name: ".google.protobuf.Any",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "instrument",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [
+        %Google.Protobuf.DescriptorProto{
+          name: "GEntry",
+          field: [
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "key",
+              extendee: nil,
+              number: 1,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_STRING,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "key",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "value",
+              extendee: nil,
+              number: 2,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_INT32,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "value",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            }
+          ],
+          nested_type: [],
+          enum_type: [],
+          extension_range: [],
+          extension: [],
+          options: %Google.Protobuf.MessageOptions{
+            message_set_wire_format: false,
+            no_standard_descriptor_accessor: false,
+            deprecated: false,
+            map_entry: true,
+            deprecated_legacy_json_field_conflicts: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
+          oneof_decl: [],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        }
+      ],
+      enum_type: [],
+      extension_range: [
+        %Google.Protobuf.DescriptorProto.ExtensionRange{
+          start: 10,
+          end: 21,
+          options: nil,
+          __unknown_fields__: []
+        }
+      ],
+      extension: [],
+      options: nil,
+      oneof_decl: [
+        %Google.Protobuf.OneofDescriptorProto{
+          name: "test_oneof",
+          options: nil,
+          __unknown_fields__: []
+        }
+      ],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  oneof :test_oneof, 0
+
+  field :name, 1, required: true, type: :string
+  field :enum, 2, optional: true, type: TestserviceV2.Enum, enum: true
+  field :label, 3, optional: true, type: :string, oneof: 0
+  field :value, 4, optional: true, type: :int32, oneof: 0
+  field :g, 5, repeated: true, type: TestserviceV2.TestRequest.GEntry, map: true
+  field :instrument, 6, repeated: true, type: Google.Protobuf.Any
+
+  extensions [{10, 21}]
+end
+
+defmodule TestserviceV2.TestReply do
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto2
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestReply",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "today",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_REQUIRED,
+          type: :TYPE_MESSAGE,
+          type_name: ".google.protobuf.Timestamp",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "today",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :today, 2, required: true, type: Google.Protobuf.Timestamp
+end
+
+defmodule TestserviceV2.TestService.Service do
+  use GRPC.Service, name: "testserviceV2.TestService", protoc_gen_elixir_version: "0.12.0"
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.ServiceDescriptorProto{
+      name: "TestService",
+      method: [
+        %Google.Protobuf.MethodDescriptorProto{
+          name: "CallFunction",
+          input_type: ".testserviceV2.TestRequest",
+          output_type: ".testserviceV2.TestReply",
+          options: %Google.Protobuf.MethodOptions{
+            deprecated: false,
+            idempotency_level: :IDEMPOTENCY_UNKNOWN,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
+          client_streaming: false,
+          server_streaming: false,
+          __unknown_fields__: []
+        }
+      ],
+      options: nil,
+      __unknown_fields__: []
+    }
+  end
+
+  rpc :CallFunction, TestserviceV2.TestRequest, TestserviceV2.TestReply
+end
+
+defmodule TestserviceV2.TestService.Stub do
+  use GRPC.Stub, service: TestserviceV2.TestService.Service
+end

--- a/test/support/protos/test_service_v3.pb.ex
+++ b/test/support/protos/test_service_v3.pb.ex
@@ -1,4 +1,4 @@
-defmodule Testservice.Enum do
+defmodule TestserviceV3.Enum do
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   def descriptor do
@@ -30,7 +30,7 @@ defmodule Testservice.Enum do
   field :B, 1
 end
 
-defmodule Testservice.TestRequest.GEntry do
+defmodule TestserviceV3.TestRequest.GEntry do
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   def descriptor do
@@ -92,7 +92,7 @@ defmodule Testservice.TestRequest.GEntry do
   field :value, 2, type: :int32
 end
 
-defmodule Testservice.TestRequest do
+defmodule TestserviceV3.TestRequest do
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   def descriptor do
@@ -120,7 +120,7 @@ defmodule Testservice.TestRequest do
           number: 2,
           label: :LABEL_OPTIONAL,
           type: :TYPE_ENUM,
-          type_name: ".testservice.Enum",
+          type_name: ".testserviceV3.Enum",
           default_value: nil,
           options: nil,
           oneof_index: nil,
@@ -162,7 +162,7 @@ defmodule Testservice.TestRequest do
           number: 5,
           label: :LABEL_REPEATED,
           type: :TYPE_MESSAGE,
-          type_name: ".testservice.TestRequest.GEntry",
+          type_name: ".testserviceV3.TestRequest.GEntry",
           default_value: nil,
           options: nil,
           oneof_index: nil,
@@ -258,14 +258,14 @@ defmodule Testservice.TestRequest do
   oneof :test_oneof, 0
 
   field :name, 1, type: :string
-  field :enum, 2, type: Testservice.Enum, enum: true
+  field :enum, 2, type: TestserviceV3.Enum, enum: true
   field :label, 3, type: :string, oneof: 0
   field :value, 4, type: :int32, oneof: 0
-  field :g, 5, repeated: true, type: Testservice.TestRequest.GEntry, map: true
+  field :g, 5, repeated: true, type: TestserviceV3.TestRequest.GEntry, map: true
   field :instrument, 6, type: Google.Protobuf.Any
 end
 
-defmodule Testservice.TestReply do
+defmodule TestserviceV3.TestReply do
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   def descriptor do
@@ -303,8 +303,8 @@ defmodule Testservice.TestReply do
   field :today, 2, type: Google.Protobuf.Timestamp
 end
 
-defmodule Testservice.TestService.Service do
-  use GRPC.Service, name: "testservice.TestService", protoc_gen_elixir_version: "0.12.0"
+defmodule TestserviceV3.TestService.Service do
+  use GRPC.Service, name: "testserviceV3.TestService", protoc_gen_elixir_version: "0.12.0"
 
   def descriptor do
     # credo:disable-for-next-line
@@ -313,8 +313,8 @@ defmodule Testservice.TestService.Service do
       method: [
         %Google.Protobuf.MethodDescriptorProto{
           name: "CallFunction",
-          input_type: ".testservice.TestRequest",
-          output_type: ".testservice.TestReply",
+          input_type: ".testserviceV3.TestRequest",
+          output_type: ".testserviceV3.TestReply",
           options: %Google.Protobuf.MethodOptions{
             deprecated: false,
             idempotency_level: :IDEMPOTENCY_UNKNOWN,
@@ -332,9 +332,9 @@ defmodule Testservice.TestService.Service do
     }
   end
 
-  rpc :CallFunction, Testservice.TestRequest, Testservice.TestReply
+  rpc :CallFunction, TestserviceV3.TestRequest, TestserviceV3.TestReply
 end
 
-defmodule Testservice.TestService.Stub do
-  use GRPC.Stub, service: Testservice.TestService.Service
+defmodule TestserviceV3.TestService.Stub do
+  use GRPC.Stub, service: TestserviceV3.TestService.Service
 end

--- a/test/support/protos/testservice_v2/pb_extension.pb.ex
+++ b/test/support/protos/testservice_v2/pb_extension.pb.ex
@@ -1,0 +1,6 @@
+defmodule TestserviceV2.PbExtension do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.12.0"
+
+  extend TestserviceV2.TestRequest, :extended_field, 10, optional: true, type: :string
+end


### PR DESCRIPTION
This reflection module doesn't support proto2.  To better attempt to support it in the future, this PR adds a proto2 test proto with an accompanying test.  As we find types in proto2 that aren't supported, we can add them there and enhance the module.