### PR TITLE
lookup syntax value and populate with proto2 or proto3

### DIFF
--- a/lib/grpc_reflection/service/builder.ex
+++ b/lib/grpc_reflection/service/builder.ex
@@ -150,9 +150,9 @@ defmodule GrpcReflection.Service.Builder do
           _ -> false
         end)
         |> then(fn
-          nil -> raise "bad module, no biscuit"
+          nil -> "proto2"
           {_, {req, _}, _} -> get_syntax(req)
-          {_, req, _} -> get_syntax(req)
+          {_, _, {req, _}} -> get_syntax(req)
         end)
 
       true ->

--- a/priv/protos/test_service_v2.proto
+++ b/priv/protos/test_service_v2.proto
@@ -9,6 +9,10 @@ service TestService {
   rpc CallFunction (TestRequest) returns (TestReply) {}
 }
 
+service EmptyService {
+  
+}
+
 message TestRequest {
   required string name = 1;
   optional Enum enum = 2;

--- a/test/builder_test.exs
+++ b/test/builder_test.exs
@@ -30,6 +30,13 @@ defmodule GrpcReflection.BuilderTest do
              "testserviceV3.TestService",
              "testserviceV3.TestService.CallFunction"
            ]
+
+    (Map.values(tree.files) ++ Map.values(tree.symbols))
+    |> Enum.flat_map(&Map.get(&1, :file_descriptor_proto))
+    |> Enum.map(&Google.Protobuf.FileDescriptorProto.decode/1)
+    |> Enum.each(fn payload ->
+      assert payload.syntax == "proto3"
+    end)
   end
 
   test "supports all reflection types in proto2" do
@@ -56,5 +63,14 @@ defmodule GrpcReflection.BuilderTest do
              "testserviceV2.TestService",
              "testserviceV2.TestService.CallFunction"
            ]
+
+    (Map.values(tree.files) ++ Map.values(tree.symbols))
+    |> Enum.flat_map(&Map.get(&1, :file_descriptor_proto))
+    |> Enum.map(&Google.Protobuf.FileDescriptorProto.decode/1)
+    |> Enum.each(fn
+      # the google types are proto3
+      %{name: "google" <> _} = payload -> assert payload.syntax == "proto3"
+      payload -> assert payload.syntax == "proto2"
+    end)
   end
 end

--- a/test/builder_test.exs
+++ b/test/builder_test.exs
@@ -73,4 +73,29 @@ defmodule GrpcReflection.BuilderTest do
       payload -> assert payload.syntax == "proto2"
     end)
   end
+
+  test "handles an empty service" do
+    tree = Builder.build_reflection_tree([TestserviceV2.EmptyService.Service])
+    assert %Agent{services: [TestserviceV2.EmptyService.Service]} = tree
+
+    (Map.values(tree.files) ++ Map.values(tree.symbols))
+    |> Enum.flat_map(&Map.get(&1, :file_descriptor_proto))
+    |> Enum.map(&Google.Protobuf.FileDescriptorProto.decode/1)
+    |> Enum.each(fn payload ->
+      # empty services default to proto2
+      assert payload.syntax == "proto2"
+      assert payload.dependency == []
+      assert payload.message_type == []
+      assert payload.enum_type == []
+
+      assert payload.service == [
+               %Google.Protobuf.ServiceDescriptorProto{
+                 name: "EmptyService",
+                 method: [],
+                 options: nil,
+                 __unknown_fields__: []
+               }
+             ]
+    end)
+  end
 end

--- a/test/support/protos/test_service_v2.pb.ex
+++ b/test/support/protos/test_service_v2.pb.ex
@@ -347,3 +347,21 @@ end
 defmodule TestserviceV2.TestService.Stub do
   use GRPC.Stub, service: TestserviceV2.TestService.Service
 end
+
+defmodule TestserviceV2.EmptyService.Service do
+  use GRPC.Service, name: "testserviceV2.EmptyService", protoc_gen_elixir_version: "0.12.0"
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.ServiceDescriptorProto{
+      name: "EmptyService",
+      method: [],
+      options: nil,
+      __unknown_fields__: []
+    }
+  end
+end
+
+defmodule TestserviceV2.EmptyService.Stub do
+  use GRPC.Stub, service: TestserviceV2.EmptyService.Service
+end


### PR DESCRIPTION
We have been ignoring the `syntax` field on the reflected protos, allowing it to default to `proto2`.

This PR adds a lookup function to get the syntax of a message type, or for a service the syntax of the first request message, and uses that to populate the syntax.

This isn't 100%, and will not be able to resolve the syntax of a service that only has zero-arity functions. 